### PR TITLE
Monitor client fix for mvn shade in dependencies.

### DIFF
--- a/development/libraries/monitor-client/pom.xml
+++ b/development/libraries/monitor-client/pom.xml
@@ -29,16 +29,16 @@
             <version>2.9.1</version>
         </dependency>
 
-	<dependency>
-	    <groupId>org.jboss.spec.javax.net.ssl</groupId>
-	    <artifactId>jboss-jsse-api_8.0_spec</artifactId>
-	    <version>1.0.0.Final</version>
-	</dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.net.ssl</groupId>
+            <artifactId>jboss-jsse-api_8.0_spec</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
 
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1-m09</version>
+            <version>2.1</version>
         </dependency>
         
         <dependency>
@@ -104,7 +104,7 @@
         
         <plugins><!-- add your plugins -->
             <!-- If you need your jar to include the dependencies -->
-            <!--            <plugin>
+            <!--<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
@@ -117,8 +117,13 @@
                 </executions>
                 <configuration>
                     <finalName>${project.artifactId}-${project.version}-standalone</finalName>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                    </transformers>
                 </configuration>
             </plugin>-->
+           
         </plugins>        
         
         <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
@@ -156,6 +161,7 @@
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.1.1</version>
                 </plugin>
+                
             </plugins>
         </pluginManagement>
     </build>

--- a/development/probes/probe-demo/src/main/java/eu/atmosphere/tmaf/probe/Main.java
+++ b/development/probes/probe-demo/src/main/java/eu/atmosphere/tmaf/probe/Main.java
@@ -37,6 +37,7 @@ public class Main {
      */
     public static void main(String[] args) {
         LOGGER.info("Trust me! This is ATMOSPHERE!");
+//        BackgroundClient client = new BackgroundClient("http://127.0.0.1:5000/monitor");
         BackgroundClient client = new BackgroundClient();
 
         client.authenticate(1098, "pass".getBytes());


### PR DESCRIPTION
* Both the shade or assembly plugin cause that some of the dependencies
start working incorrectly (see error below).

*The solution is to add transformers to better handle the manifests.

Error:
`SEVERE: MessageBodyWriter not found for media type=application/json,
type=class eu.atmosphere.tmaf.monitor.message.Message,
genericType=class eu.atmosphere.tmaf.monitor.message.Message.`