### PR TITLE
Remove Unnecessary Apache Kafka Topic

### DIFF
--- a/development/server/setup-testing-mode.sh
+++ b/development/server/setup-testing-mode.sh
@@ -16,4 +16,3 @@ kubectl create -f kafka/kafka.yaml
 sleep 20
 
 kubectl exec -ti kafka-0 -- kafka-topics.sh --create --topic topic-monitor --zookeeper zk-0.zk-hs.default.svc.cluster.local:2181 --partitions 1 --replication-factor 1
-kubectl exec -ti kafka-0 -- kafka-topics.sh --create --topic queue-listener --zookeeper zk-0.zk-hs.default.svc.cluster.local:2181 --partitions 1 --replication-factor 1


### PR DESCRIPTION
- queue-listener topic is not needed because Apache Flume is deprecated.