### PR TITLE
Bug fix of the version of Java Probe Library

### DIFF
--- a/development/libraries/java-client-lib/README.md
+++ b/development/libraries/java-client-lib/README.md
@@ -28,7 +28,7 @@ To use the monitor-client in the development of your probe, you just need to inc
 <dependency>
     <groupId>eu.atmosphere.tmaf</groupId>
     <artifactId>java-client-lib</artifactId>
-    <version>0.1</version>
+    <version>0.2</version>
 </dependency>
 ```
 

--- a/development/libraries/java-client-lib/pom.xml
+++ b/development/libraries/java-client-lib/pom.xml
@@ -44,23 +44,23 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.10</version>
         </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.8,)</version>
+            <version>2.9.10</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
The versions of Jackson were not consistent (each library was importing a different version).
They were all updated.